### PR TITLE
[squid:S1125] Literal boolean values should not be used in condition expressions

### DIFF
--- a/src/main/java/com/mook/locker/cache/LocalVersionLockerCache.java
+++ b/src/main/java/com/mook/locker/cache/LocalVersionLockerCache.java
@@ -34,11 +34,11 @@ public class LocalVersionLockerCache implements VersionLockerCache {
 		if(null == cache || cache.isEmpty()) {
 			return false;
 		}
-		boolean contain = cache.containsKey(vm);
-		if(true == contain && log.isDebugEnabled()) {
+		boolean containsMethodSignature = cache.containsKey(vm);
+		if(containsMethodSignature && log.isDebugEnabled()) {
 			log.debug("The method " + nameSpace + vm.getId() + "is hit in cache.");
 		}
-		return contain;
+		return containsMethodSignature;
 	}
 	
 	// 这里去掉synchronized或者重入锁，因为这里的操作满足幂等性

--- a/src/main/java/com/mook/locker/interceptor/OptimisticLocker.java
+++ b/src/main/java/com/mook/locker/interceptor/OptimisticLocker.java
@@ -111,7 +111,7 @@ public class OptimisticLocker implements Interceptor {
 			BoundSql boundSql = (BoundSql) hm.getValue("delegate.boundSql");
 			
 			VersionLocker vl = getVersionLocker(ms, boundSql);
-			if(null != vl && vl.value() == false) {
+			if(null != vl && !vl.value()) {
 				return invocation.proceed();
 			}
 			
@@ -147,7 +147,7 @@ public class OptimisticLocker implements Interceptor {
 			BoundSql boundSql = (BoundSql) hm.getValue("boundSql");
 			
 			VersionLocker vl = getVersionLocker(ms, boundSql);
-			if(null != vl && vl.value() == false) {
+			if(null != vl && !vl.value()) {
 				return invocation.proceed();
 			}
 			


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1125- “Literal boolean values should not be used in condition expressions”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1125

Please let me know if you have any questions.
Ayman Abdelghany.