### PR TITLE
[squid:S1166] Exception handlers should preserve the original exception

### DIFF
--- a/src/main/java/com/mook/locker/interceptor/OptimisticLocker.java
+++ b/src/main/java/com/mook/locker/interceptor/OptimisticLocker.java
@@ -74,7 +74,7 @@ public class OptimisticLocker implements Interceptor {
 		try {
 			trueLocker = new OptimisticLocker().getClass().getDeclaredMethod("versionValue").getAnnotation(VersionLocker.class);
 		} catch (NoSuchMethodException | SecurityException e) {
-			throw new RuntimeException("The plugin init faild.");
+			throw new RuntimeException("The plugin init faild.", e);
 		}
 	}
 	


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1166- “Exception handlers should preserve the original exception”. 

You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1166

Please let me know if you have any questions.
Ayman Abdelghany.