### PR TITLE
[squid:S2133] Objects should not be created only to "getClass"

### DIFF
--- a/src/main/java/com/mook/locker/interceptor/OptimisticLocker.java
+++ b/src/main/java/com/mook/locker/interceptor/OptimisticLocker.java
@@ -72,7 +72,7 @@ public class OptimisticLocker implements Interceptor {
 	private static VersionLocker trueLocker;
 	static {
 		try {
-			trueLocker = new OptimisticLocker().getClass().getDeclaredMethod("versionValue").getAnnotation(VersionLocker.class);
+			trueLocker = OptimisticLocker.class.getDeclaredMethod("versionValue").getAnnotation(VersionLocker.class);
 		} catch (NoSuchMethodException | SecurityException e) {
 			throw new RuntimeException("The plugin init faild.");
 		}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2133 - “Objects should not be created only to "getClass" ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2133

Please let me know if you have any questions.
Ayman Abdelghany.