### PR TITLE
[squid:S1488] Local Variables should not be declared and then immediately returned or thrown

### DIFF
--- a/src/main/java/com/mook/locker/cache/LocalVersionLockerCache.java
+++ b/src/main/java/com/mook/locker/cache/LocalVersionLockerCache.java
@@ -72,8 +72,7 @@ public class LocalVersionLockerCache implements VersionLockerCache {
 	private String getNameSpace(VersionLockerCache.MethodSignature vm) {
 		String id = vm.getId();
 		int pos = id.lastIndexOf(".");
-		String nameSpace = id.substring(0, pos);
-		return nameSpace;
+		return id.substring(0, pos);
 	}
 
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1488 - “Local Variables should not be declared and then immediately returned or thrown”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1488

Please let me know if you have any questions.
Ayman Abdelghany.