### PR TITLE
[squid:S2293] The operator ("<>") should be used.

### DIFF
--- a/src/main/java/com/mook/locker/interceptor/OptimisticLocker.java
+++ b/src/main/java/com/mook/locker/interceptor/OptimisticLocker.java
@@ -247,7 +247,7 @@ public class OptimisticLocker implements Interceptor {
 		// 这里去掉synchronized或者重入锁，因为这里的操作满足幂等性
 		// Here remove synchronized keyword or ReentrantLock, because it's a idempotent operation
 		if(null == mapperMap || mapperMap.isEmpty()) {
-			mapperMap = new HashMap<String, Class<?>>();
+			mapperMap = new HashMap<>();
 			Collection<Class<?>> mappers = ms.getConfiguration().getMapperRegistry().getMappers();
 			if(null != mappers && !mappers.isEmpty()) {
 				for (Class<?> me : mappers) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2293 - “The diamond operator ("<>") should be used ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293

Please let me know if you have any questions.
Ayman Abdelghany.